### PR TITLE
GitHub 認証ボタンをコメントアウトで ignore する

### DIFF
--- a/apps/client/src/components/templates/AccountSetting/index.tsx
+++ b/apps/client/src/components/templates/AccountSetting/index.tsx
@@ -88,7 +88,7 @@ const AccountSettingTemplate: FC<Props> = ({ user }) => {
 
       <ScreenNameForm user={user} />
 
-      <GitHubConnectForm user={user} />
+      {/* <GitHubConnectForm user={user} /> */}
 
       <PasswordForm />
     </Wrapper>

--- a/apps/client/src/components/templates/SignIn/index.tsx
+++ b/apps/client/src/components/templates/SignIn/index.tsx
@@ -259,7 +259,7 @@ const SignInTemplate = () => {
           <PrimaryButton type="submit">ログイン</PrimaryButton>
         </Form>
 
-        <Divider>または</Divider>
+        {/* <Divider>または</Divider>
 
         <GitHubButton type="button" onClick={githubSignIn}>
           <Image
@@ -269,7 +269,7 @@ const SignInTemplate = () => {
             height={20}
           />
           GitHub でログイン
-        </GitHubButton>
+        </GitHubButton> */}
 
         <LinkText>
           アカウントをお持ちでない方は{" "}


### PR DESCRIPTION
サイトの信頼が足らず、まだ OAuth 認証までは難しいので、一旦コメントアウトで非表示にする。
(復活予定があるため、処理は温存する)