### PR TITLE
fix: 投稿後のリダイレクト処理を遅延させる

### DIFF
--- a/apps/client/src/components/templates/PostCreate/index.tsx
+++ b/apps/client/src/components/templates/PostCreate/index.tsx
@@ -196,6 +196,12 @@ const PostCreateTemplate: FC<PostCreateTemplateProps> = ({ userId, theme }) => {
     try {
       setIsLoading(true);
       const post = await createPost(e.title, e.content, isPublished);
+
+      // データの反映にタイムラグがあるため、リダイレクト前に5秒待機
+      // staging環境で静的生成されたページの更新が遅延するため、
+      // データが確実に反映されてからリダイレクトする
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
       if (post.published) {
         router.push(`/post/${post.id}`);
       } else {

--- a/apps/client/src/components/templates/PostEdit/index.tsx
+++ b/apps/client/src/components/templates/PostEdit/index.tsx
@@ -205,6 +205,12 @@ const PostEditTemplate: FC<PostEditTemplateProps> = ({
     try {
       setIsLoading(true);
       const updatedPost = await updatePost(id, e.title, e.content, isPublished);
+
+      // データの反映にタイムラグがあるため、リダイレクト前に5秒待機
+      // staging環境で静的生成されたページの更新が遅延するため、
+      // データが確実に反映されてからリダイレクトする
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
       if (updatedPost.published) {
         router.push(`/post/${id}`);
       } else {


### PR DESCRIPTION
staging (本番)だと、投稿後にデータの反映が遅いので、意図的に5秒遅延させる